### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A **Model Context Protocol (MCP) server** that connects your AI assistants (Claude, Cursor, etc.) directly with Freepik's powerful APIs. Generate, search, and manage visual content without leaving your AI workflow.
 
+<a href="https://glama.ai/mcp/servers/@freepik-company/freepik-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@freepik-company/freepik-mcp/badge" alt="Freepik FastToolkit MCP server" />
+</a>
+
 ## 🛠️ What tools are available?
 
 - 🎨 **Icon Search & Download** - Find and download icons in multiple formats


### PR DESCRIPTION
This PR adds a badge for the [Freepik FastMCP Toolkit](https://glama.ai/mcp/servers/@freepik-company/freepik-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@freepik-company/freepik-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@freepik-company/freepik-mcp/badge" alt="Freepik FastToolkit MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.